### PR TITLE
Enhance quiz app UI and filtering

### DIFF
--- a/eju_app/main.py
+++ b/eju_app/main.py
@@ -1,12 +1,12 @@
 import os
 import sqlite3
-from typing import Optional, Dict, List
+import urllib.parse
+from collections import Counter
+from typing import Any, Dict, List, Optional, Set, Tuple
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
-
-import urllib.parse
 
 app = FastAPI(title="EJU Quiz App")
 
@@ -15,6 +15,15 @@ DATABASE = os.path.join(BASE_DIR, "questions.db")
 
 # Set up Jinja2 templates directory
 templates = Jinja2Templates(directory=os.path.join(BASE_DIR, "templates"))
+
+# Constants used throughout the app
+DEFAULT_SECTIONS: List[str] = ["日语", "综合科目", "理科", "未分类"]
+CORRECT_OPTION_CHOICES: Tuple[Tuple[str, str], ...] = (
+    ("A", "A"),
+    ("B", "B"),
+    ("C", "C"),
+    ("D", "D"),
+)
 
 
 def get_db():
@@ -56,34 +65,220 @@ def on_startup():
     init_db()
 
 
-def build_tag_hierarchy(tags: List[str]) -> Dict[str, List[str]]:
-    """
-    Build a hierarchical dictionary of tags from a flat list. Tags with slashes indicate parent/child relationships.
-    Example: ["数学/代数", "数学/几何", "日语"] -> {"数学": ["代数", "几何"], "日语": []}
-    """
-    hierarchy: Dict[str, List[str]] = {}
+def parse_tags(tags_value: Optional[str]) -> List[str]:
+    """Split a comma-separated tag string into a cleaned list."""
+
+    if not tags_value:
+        return []
+    tags: List[str] = []
+    for tag in tags_value.split(","):
+        cleaned = tag.strip()
+        if cleaned:
+            tags.append(cleaned)
+    return tags
+
+
+def normalize_tags_string(tags_value: str) -> str:
+    """Normalize tag input by trimming whitespace and removing duplicates while keeping order."""
+
+    seen = set()
+    normalized: List[str] = []
+    for tag in parse_tags(tags_value):
+        if tag not in seen:
+            normalized.append(tag)
+            seen.add(tag)
+    return ", ".join(normalized)
+
+
+def build_tag_tree(tags: List[str]) -> Dict[str, Any]:
+    """Convert a list of slash-separated tags into a nested dictionary tree."""
+
+    tree: Dict[str, Dict[str, Any]] = {}
     for tag in tags:
         parts = [p.strip() for p in tag.split("/") if p.strip()]
         if not parts:
             continue
-        parent = parts[0]
-        if len(parts) == 1:
-            hierarchy.setdefault(parent, [])
-        else:
-            child = "/".join(parts[1:])
-            hierarchy.setdefault(parent, [])
-            if child not in hierarchy[parent]:
-                hierarchy[parent].append(child)
-    # Sort children and parents for consistent ordering
-    for parent in hierarchy:
-        hierarchy[parent].sort()
-    return dict(sorted(hierarchy.items()))
+        node = tree
+        for part in parts:
+            node = node.setdefault(part, {})  # type: ignore[assignment]
+    return tree
+
+
+def build_tag_options(tags: List[str]) -> List[Dict[str, Any]]:
+    """Build select options (value, label, level) from a tag list."""
+
+    tree = build_tag_tree(tags)
+
+    def walk(node: Dict[str, Any], prefix: str = "", level: int = 0) -> List[Dict[str, Any]]:
+        options: List[Dict[str, Any]] = []
+        for key in sorted(node.keys()):
+            value = f"{prefix}/{key}" if prefix else key
+            options.append({"value": value, "label": key, "level": level})
+            options.extend(walk(node[key], value, level + 1))
+        return options
+
+    return walk(tree)
+
+
+def format_tag_label(tag_value: Optional[str]) -> str:
+    """Format a tag path for display."""
+
+    if not tag_value:
+        return ""
+    parts = [p.strip() for p in tag_value.split("/") if p.strip()]
+    return " / ".join(parts)
+
+
+def gather_sections_metadata(
+    conn: sqlite3.Connection,
+) -> Tuple[List[Dict[str, Any]], int, List[str]]:
+    """Return section overview (count and top tags), total question count and global hot tags."""
+
+    stats: Dict[str, Dict[str, Any]] = {}
+    total_questions = 0
+    overall_tags: Counter[str] = Counter()
+    cur = conn.execute("SELECT section, tags FROM questions")
+    for row in cur.fetchall():
+        raw_section = row["section"] or "未分类"
+        section_name = raw_section.strip() or "未分类"
+        entry = stats.setdefault(
+            section_name,
+            {"count": 0, "tags": Counter()},
+        )
+        entry["count"] += 1
+        total_questions += 1
+        tag_list = parse_tags(row["tags"])
+        entry["tags"].update(tag_list)
+        overall_tags.update(tag_list)
+
+    sections: List[Dict[str, Any]] = []
+    seen: Set[str] = set()
+
+    def build_section_entry(name: str) -> Dict[str, Any]:
+        entry = stats.get(name, {"count": 0, "tags": Counter()})
+        top_tags = [tag for tag, _ in entry["tags"].most_common(4)]
+        return {
+            "name": name,
+            "display_name": name,
+            "count": entry["count"],
+            "top_tags": top_tags,
+        }
+
+    for name in DEFAULT_SECTIONS:
+        sections.append(build_section_entry(name))
+        seen.add(name)
+
+    for name in sorted(stats.keys()):
+        if name in seen:
+            continue
+        sections.append(build_section_entry(name))
+        seen.add(name)
+
+    top_tags = [tag for tag, _ in overall_tags.most_common(12)]
+
+    return sections, total_questions, top_tags
+
+
+def get_section_choices(conn: sqlite3.Connection) -> List[str]:
+    """Return section choices for forms (defaults + existing unique sections)."""
+
+    cur = conn.execute(
+        "SELECT DISTINCT section FROM questions WHERE section IS NOT NULL AND trim(section) <> ''"
+    )
+    existing = [row["section"] for row in cur.fetchall() if row["section"]]
+    seen: Set[str] = set()
+    choices: List[str] = []
+    for name in DEFAULT_SECTIONS:
+        if name not in seen:
+            choices.append(name)
+            seen.add(name)
+    for name in existing:
+        if name not in seen:
+            choices.append(name)
+            seen.add(name)
+    return choices
+
+
+def make_feedback(msg: Optional[str], category: Optional[str]) -> List[Dict[str, str]]:
+    """Build feedback messages for the template."""
+
+    if not msg:
+        return []
+    normalized = category if category in {"success", "error", "info"} else "info"
+    return [{"category": normalized, "text": msg}]
+
+
+def parse_form_body(body_bytes: bytes) -> Dict[str, str]:
+    """Parse URL-encoded form body into a simple dict."""
+
+    parsed = urllib.parse.parse_qs(body_bytes.decode())
+    return {key: (values[0].strip() if values else "") for key, values in parsed.items()}
+
+
+def validate_question_payload(data: Dict[str, str]) -> Tuple[List[str], Dict[str, str]]:
+    """Validate and normalize question payload from a form."""
+
+    errors: List[str] = []
+
+    question = data.get("question", "").strip()
+    option_a = data.get("option_a", "").strip()
+    option_b = data.get("option_b", "").strip()
+    option_c = data.get("option_c", "").strip()
+    option_d = data.get("option_d", "").strip()
+    correct_option = data.get("correct_option", "").strip().upper()
+    section = data.get("section", "").strip()
+    tags = data.get("tags", "")
+
+    if not question:
+        errors.append("题目内容不能为空。")
+    if not option_a or not option_b or not option_c or not option_d:
+        errors.append("请填写四个选项内容。")
+    if correct_option not in {choice[0] for choice in CORRECT_OPTION_CHOICES}:
+        errors.append("请选择正确答案。")
+    if not section:
+        errors.append("请选择题目所属的板块。")
+
+    normalized_tags = normalize_tags_string(tags)
+
+    payload = {
+        "question": question,
+        "option_a": option_a,
+        "option_b": option_b,
+        "option_c": option_c,
+        "option_d": option_d,
+        "correct_option": correct_option,
+        "section": section,
+        "tags": normalized_tags,
+    }
+    return errors, payload
+
+
+def enrich_question_row(row: sqlite3.Row) -> Dict[str, Any]:
+    """Convert a question row into a dict enriched with parsed tags."""
+
+    data = dict(row)
+    data["section"] = data.get("section") or "未分类"
+    data["tag_list"] = parse_tags(data.get("tags"))
+    return data
 
 
 @app.get("/", response_class=HTMLResponse)
 async def home(request: Request):
     """Home page: let the user choose a section."""
-    return templates.TemplateResponse("home.html", {"request": request})
+
+    with get_db() as conn:
+        sections, total_questions, top_tags = gather_sections_metadata(conn)
+
+    return templates.TemplateResponse(
+        "home.html",
+        {
+            "request": request,
+            "sections": sections,
+            "total_questions": total_questions,
+            "top_tags": top_tags,
+            "feedback": [],
+        },
+    )
 
 
 @app.get("/quiz", response_class=HTMLResponse)
@@ -91,46 +286,70 @@ async def quiz(
     request: Request,
     tag: Optional[str] = None,
     section: Optional[str] = None,
+    search: Optional[str] = None,
 ):
-    """Display the quiz page with optional section and tag filters."""
+    """Display the quiz page with optional section, tag and keyword filters."""
+
+    tag_filter = (tag or "").strip()
+    section_filter = (section or "").strip()
+    search_filter = (search or "").strip()
+
     with get_db() as conn:
         base_query = "SELECT * FROM questions"
-        conditions = []
-        params = []
-        if section:
+        conditions: List[str] = []
+        params: List[Any] = []
+        if section_filter:
             conditions.append("section = ?")
-            params.append(section)
-        if tag:
+            params.append(section_filter)
+        if tag_filter:
             conditions.append("lower(tags) LIKE lower(?)")
-            params.append(f"%{tag}%")
+            params.append(f"%{tag_filter}%")
+        if search_filter:
+            like_value = f"%{search_filter}%"
+            conditions.append(
+                "(" "question LIKE ? OR option_a LIKE ? OR option_b LIKE ? OR option_c LIKE ? OR option_d LIKE ? OR tags LIKE ?" ")"
+            )
+            params.extend([like_value] * 6)
         if conditions:
             base_query += " WHERE " + " AND ".join(conditions)
         base_query += " ORDER BY id"
         cur = conn.execute(base_query, tuple(params))
-        questions = cur.fetchall()
+        questions_raw = cur.fetchall()
+        questions = [enrich_question_row(row) for row in questions_raw]
 
         # Collect all tags (within the selected section, if any)
         tag_query = "SELECT tags FROM questions"
-        tag_params = ()
-        if section:
-            tag_query += " WHERE section = ?"
-            tag_params = (section,)
-        tag_cur = conn.execute(tag_query, tag_params)
-        tags_all = []
+        tag_conditions: List[str] = []
+        tag_params: List[Any] = []
+        if section_filter:
+            tag_conditions.append("section = ?")
+            tag_params.append(section_filter)
+        if tag_conditions:
+            tag_query += " WHERE " + " AND ".join(tag_conditions)
+        tag_cur = conn.execute(tag_query, tuple(tag_params))
+        tags_all: List[str] = []
         for row in tag_cur.fetchall():
-            if row[0]:
-                tags_all.extend([t.strip() for t in row[0].split(",") if t.strip()])
+            tags_all.extend(parse_tags(row["tags"]))
         tags_unique = sorted(set(tags_all))
-        tags_hierarchy = build_tag_hierarchy(tags_unique)
+        tag_options = build_tag_options(tags_unique)
+
+        sections_metadata, _, _ = gather_sections_metadata(conn)
+
+    selected_section_display = section_filter or "全部题目"
 
     return templates.TemplateResponse(
         "quiz.html",
         {
             "request": request,
             "questions": questions,
-            "tags_hierarchy": tags_hierarchy,
-            "selected_tag": tag or "",
-            "selected_section": section or "",
+            "tag_options": tag_options,
+            "selected_tag": tag_filter,
+            "selected_tag_label": format_tag_label(tag_filter),
+            "selected_section": section_filter,
+            "selected_section_display": selected_section_display,
+            "sections": sections_metadata,
+            "search": search_filter,
+            "feedback": [],
         },
     )
 
@@ -148,14 +367,17 @@ async def submit_quiz(request: Request):
             answers[qid] = values[0]
     if not answers:
         # If no answers were submitted, redirect back to quiz
-        return RedirectResponse(url="/quiz", status_code=303)
+        return RedirectResponse(url="/quiz", status_code=status.HTTP_303_SEE_OTHER)
+
     placeholders = ",".join("?" for _ in answers)
     with get_db() as conn:
-        cur = conn.execute(
-            f"SELECT id, correct_option FROM questions WHERE id IN ({placeholders})",
-            list(answers.keys()),
-        )
+        query = (
+            "SELECT id, question, option_a, option_b, option_c, option_d, "
+            "correct_option, tags, section FROM questions WHERE id IN ({})"
+        ).format(placeholders)
+        cur = conn.execute(query, list(answers.keys()))
         result_set = cur.fetchall()
+
     total = len(result_set)
     correct = 0
     details = []
@@ -169,9 +391,18 @@ async def submit_quiz(request: Request):
         details.append(
             {
                 "id": qid,
+                "question": row["question"],
+                "options": [
+                    ("A", row["option_a"]),
+                    ("B", row["option_b"]),
+                    ("C", row["option_c"]),
+                    ("D", row["option_d"]),
+                ],
                 "user_answer": user_answer,
                 "correct_answer": correct_answer,
                 "is_correct": is_correct,
+                "section": row["section"] or "未分类",
+                "tag_list": parse_tags(row["tags"]),
             }
         )
     score_percent = 0.0
@@ -185,6 +416,7 @@ async def submit_quiz(request: Request):
             "correct": correct,
             "score": score_percent,
             "details": details,
+            "feedback": [],
         },
     )
 
@@ -194,18 +426,67 @@ async def admin(
     request: Request,
     msg: Optional[str] = None,
     category: Optional[str] = None,
+    section: Optional[str] = None,
+    tag: Optional[str] = None,
+    search: Optional[str] = None,
 ):
     """Display the admin interface with a list of questions."""
+
+    tag_filter = (tag or "").strip()
+    section_filter = (section or "").strip()
+    search_filter = (search or "").strip()
+
     with get_db() as conn:
-        cur = conn.execute("SELECT * FROM questions ORDER BY id")
-        questions = cur.fetchall()
+        base_query = "SELECT * FROM questions"
+        conditions: List[str] = []
+        params: List[Any] = []
+        if section_filter:
+            conditions.append("section = ?")
+            params.append(section_filter)
+        if tag_filter:
+            conditions.append("lower(tags) LIKE lower(?)")
+            params.append(f"%{tag_filter}%")
+        if search_filter:
+            like_value = f"%{search_filter}%"
+            conditions.append(
+                "(" "question LIKE ? OR option_a LIKE ? OR option_b LIKE ? OR option_c LIKE ? OR option_d LIKE ? OR tags LIKE ?" ")"
+            )
+            params.extend([like_value] * 6)
+        if conditions:
+            base_query += " WHERE " + " AND ".join(conditions)
+        base_query += " ORDER BY id"
+        cur = conn.execute(base_query, tuple(params))
+        questions_raw = cur.fetchall()
+        questions = [enrich_question_row(row) for row in questions_raw]
+
+        sections_metadata, _, _ = gather_sections_metadata(conn)
+
+        tag_query = "SELECT tags FROM questions"
+        tag_conditions: List[str] = []
+        tag_params: List[Any] = []
+        if section_filter:
+            tag_conditions.append("section = ?")
+            tag_params.append(section_filter)
+        if tag_conditions:
+            tag_query += " WHERE " + " AND ".join(tag_conditions)
+        tag_cur = conn.execute(tag_query, tuple(tag_params))
+        tags_all: List[str] = []
+        for row in tag_cur.fetchall():
+            tags_all.extend(parse_tags(row["tags"]))
+        tags_unique = sorted(set(tags_all))
+        tag_options = build_tag_options(tags_unique)
+
     return templates.TemplateResponse(
         "admin.html",
         {
             "request": request,
             "questions": questions,
-            "msg": msg,
-            "category": category,
+            "sections": sections_metadata,
+            "tag_options": tag_options,
+            "selected_section": section_filter,
+            "selected_tag": tag_filter,
+            "search": search_filter,
+            "feedback": make_feedback(msg, category),
         },
     )
 
@@ -213,12 +494,19 @@ async def admin(
 @app.get("/admin/add", response_class=HTMLResponse)
 async def add_question_get(request: Request):
     """Render the form to add a new question."""
+    with get_db() as conn:
+        section_choices = get_section_choices(conn)
+
     return templates.TemplateResponse(
         "add_edit.html",
         {
             "request": request,
             "action": "add",
             "question_data": None,
+            "form_errors": [],
+            "correct_option_choices": CORRECT_OPTION_CHOICES,
+            "section_choices": section_choices,
+            "feedback": [],
         },
     )
 
@@ -227,36 +515,43 @@ async def add_question_get(request: Request):
 async def add_question_post(request: Request):
     """Handle submission of a new question."""
     body_bytes = await request.body()
-    data = urllib.parse.parse_qs(body_bytes.decode())
+    form_data = parse_form_body(body_bytes)
+    errors, payload = validate_question_payload(form_data)
 
-    def get_field(field: str) -> str:
-        return data.get(field, [""])[0].strip()
-
-    question = get_field("question")
-    option_a = get_field("option_a")
-    option_b = get_field("option_b")
-    option_c = get_field("option_c")
-    option_d = get_field("option_d")
-    correct_option = get_field("correct_option")
-    tags = get_field("tags")
-    section = get_field("section")
     with get_db() as conn:
+        section_choices = get_section_choices(conn)
+        if errors:
+            return templates.TemplateResponse(
+                "add_edit.html",
+                {
+                    "request": request,
+                    "action": "add",
+                    "question_data": payload,
+                    "form_errors": errors,
+                    "correct_option_choices": CORRECT_OPTION_CHOICES,
+                    "section_choices": section_choices,
+                    "feedback": [],
+                },
+                status_code=400,
+            )
+
         conn.execute(
             "INSERT INTO questions (question, option_a, option_b, option_c, option_d, correct_option, tags, section) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             (
-                question,
-                option_a,
-                option_b,
-                option_c,
-                option_d,
-                correct_option,
-                tags,
-                section,
+                payload["question"],
+                payload["option_a"],
+                payload["option_b"],
+                payload["option_c"],
+                payload["option_d"],
+                payload["correct_option"],
+                payload["tags"],
+                payload["section"],
             ),
         )
         conn.commit()
-    # Redirect to admin with success message
-    return RedirectResponse(url="/admin?msg=题目已添加&category=success", status_code=303)
+
+    admin_url = request.url_for("admin") + "?msg=题目已添加&category=success"
+    return RedirectResponse(url=admin_url, status_code=status.HTTP_303_SEE_OTHER)
 
 
 @app.get("/admin/edit/{qid}", response_class=HTMLResponse)
@@ -267,7 +562,8 @@ async def edit_question_get(request: Request, qid: int):
         row = cur.fetchone()
     if row is None:
         return RedirectResponse(
-            url="/admin?msg=题目不存在&category=error", status_code=303
+            url=f"{request.url_for('admin')}?msg=题目不存在&category=error",
+            status_code=status.HTTP_303_SEE_OTHER,
         )
     question_data = {
         "id": row["id"],
@@ -280,12 +576,18 @@ async def edit_question_get(request: Request, qid: int):
         "tags": row["tags"] or "",
         "section": row["section"] or "",
     }
+    with get_db() as conn:
+        section_choices = get_section_choices(conn)
     return templates.TemplateResponse(
         "add_edit.html",
         {
             "request": request,
             "action": "edit",
             "question_data": question_data,
+            "form_errors": [],
+            "correct_option_choices": CORRECT_OPTION_CHOICES,
+            "section_choices": section_choices,
+            "feedback": [],
         },
     )
 
@@ -294,36 +596,45 @@ async def edit_question_get(request: Request, qid: int):
 async def edit_question_post(request: Request, qid: int):
     """Handle submission of edits to an existing question."""
     body_bytes = await request.body()
-    data = urllib.parse.parse_qs(body_bytes.decode())
+    form_data = parse_form_body(body_bytes)
+    errors, payload = validate_question_payload(form_data)
 
-    def get_field(field: str) -> str:
-        return data.get(field, [""])[0].strip()
-
-    question = get_field("question")
-    option_a = get_field("option_a")
-    option_b = get_field("option_b")
-    option_c = get_field("option_c")
-    option_d = get_field("option_d")
-    correct_option = get_field("correct_option")
-    tags = get_field("tags")
-    section = get_field("section")
     with get_db() as conn:
+        section_choices = get_section_choices(conn)
+        if errors:
+            payload["id"] = qid
+            return templates.TemplateResponse(
+                "add_edit.html",
+                {
+                    "request": request,
+                    "action": "edit",
+                    "question_data": payload,
+                    "form_errors": errors,
+                    "correct_option_choices": CORRECT_OPTION_CHOICES,
+                    "section_choices": section_choices,
+                    "feedback": [],
+                },
+                status_code=400,
+            )
+
         conn.execute(
             "UPDATE questions SET question=?, option_a=?, option_b=?, option_c=?, option_d=?, correct_option=?, tags=?, section=? WHERE id=?",
             (
-                question,
-                option_a,
-                option_b,
-                option_c,
-                option_d,
-                correct_option,
-                tags,
-                section,
+                payload["question"],
+                payload["option_a"],
+                payload["option_b"],
+                payload["option_c"],
+                payload["option_d"],
+                payload["correct_option"],
+                payload["tags"],
+                payload["section"],
                 qid,
             ),
         )
         conn.commit()
-    return RedirectResponse(url="/admin?msg=题目已更新&category=success", status_code=303)
+
+    admin_url = request.url_for("admin") + "?msg=题目已更新&category=success"
+    return RedirectResponse(url=admin_url, status_code=status.HTTP_303_SEE_OTHER)
 
 
 @app.post("/admin/delete/{qid}", response_class=HTMLResponse)
@@ -332,4 +643,5 @@ async def delete_question(request: Request, qid: int):
     with get_db() as conn:
         conn.execute("DELETE FROM questions WHERE id=?", (qid,))
         conn.commit()
-    return RedirectResponse(url="/admin?msg=题目已删除&category=success", status_code=303)
+    admin_url = request.url_for("admin") + "?msg=题目已删除&category=success"
+    return RedirectResponse(url=admin_url, status_code=status.HTTP_303_SEE_OTHER)

--- a/eju_app/templates/add_edit.html
+++ b/eju_app/templates/add_edit.html
@@ -1,73 +1,113 @@
-<!DOCTYPE html>
-<html lang="zh">
-<head>
-<meta charset="UTF-8">
-<title>{% if action == 'edit' %}编辑题目{% else %}添加新题目{% endif %} - EJU 题库</title>
-<style>
-body { font-family: sans-serif; margin: 2rem; background-color: #f9fafb; color: #333; }
-h1 { color: #007bff; }
-form { margin-top: 1rem; max-width: 600px; }
-label { display: block; margin-top: 0.5rem; }
-input[type="text"], textarea, select { width: 100%; padding: 0.5rem; border: 1px solid #ccc; border-radius: 4px; }
-textarea { min-height: 80px; resize: vertical; }
-.radio-group { margin-top: 0.5rem; }
-.radio-group label { display: inline-block; margin-right: 1rem; }
-button {
-  margin-top: 1rem;
-  padding: 0.5rem 1rem;
-  background-color: #007bff;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
+{% extends "base.html" %}
+{% block title %}{% if action == 'edit' %}编辑题目{% else %}添加新题目{% endif %} - EJU 题库{% endblock %}
+{% block extra_styles %}
+.form-wrapper {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+    max-width: 720px;
 }
-button:hover { background-color: #0069d9; }
-a { text-decoration: none; color: #007bff; }
-.flash { padding: 0.5rem; margin-bottom: 1rem; border-radius: 4px; }
-.flash.error { background-color: #f8d7da; color: #842029; }
-.flash.success { background-color: #d1e7dd; color: #0f5132; }
-</style>
-</head>
-<body>
-<h1>{% if action == 'edit' %}编辑题目{% else %}添加新题目{% endif %}</h1>
-<a href="{{ url_for('admin') }}">返回后台</a>
-<form method="post">
-    <label>题目内容
-        <textarea name="question" required>{{ question_data.question if question_data else '' }}</textarea>
-    </label>
-    <label>A 选项
-        <input type="text" name="option_a" value="{{ question_data.option_a if question_data else '' }}" required>
-    </label>
-    <label>B 选项
-        <input type="text" name="option_b" value="{{ question_data.option_b if question_data else '' }}" required>
-    </label>
-    <label>C 选项
-        <input type="text" name="option_c" value="{{ question_data.option_c if question_data else '' }}" required>
-    </label>
-    <label>D 选项
-        <input type="text" name="option_d" value="{{ question_data.option_d if question_data else '' }}" required>
-    </label>
-    <label>正确答案
+
+form label {
+    display: block;
+    margin-top: 1rem;
+    font-weight: 600;
+    color: var(--muted);
+}
+
+form textarea {
+    min-height: 100px;
+}
+
+.radio-group {
+    display: flex;
+    gap: 1.25rem;
+    margin-top: 0.5rem;
+}
+
+.radio-group label {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-top: 0;
+    font-weight: 500;
+    color: var(--text-color);
+}
+
+.helper-text {
+    font-size: 0.85rem;
+    color: var(--muted);
+    margin-top: 0.35rem;
+}
+
+.form-actions {
+    margin-top: 1.5rem;
+    display: flex;
+    gap: 0.75rem;
+}
+
+.form-actions .btn {
+    flex: 1 1 160px;
+    justify-content: center;
+}
+{% endblock %}
+{% block content %}
+<h1 class="section-title">{% if action == 'edit' %}编辑题目{% else %}添加新题目{% endif %}</h1>
+<p class="subtitle">完善题干、选项、正确答案与标签，便于后续分类检索。</p>
+<div class="form-wrapper">
+    {% if form_errors %}
+    <div class="flash error">
+        <strong>请检查以下问题：</strong>
+        <ul>
+            {% for err in form_errors %}
+            <li>{{ err }}</li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+    <form method="post">
+        <label for="question">题目内容</label>
+        <textarea id="question" name="question" required>{{ question_data.question if question_data else '' }}</textarea>
+
+        <label for="option_a">A 选项</label>
+        <input type="text" id="option_a" name="option_a" value="{{ question_data.option_a if question_data else '' }}" required>
+
+        <label for="option_b">B 选项</label>
+        <input type="text" id="option_b" name="option_b" value="{{ question_data.option_b if question_data else '' }}" required>
+
+        <label for="option_c">C 选项</label>
+        <input type="text" id="option_c" name="option_c" value="{{ question_data.option_c if question_data else '' }}" required>
+
+        <label for="option_d">D 选项</label>
+        <input type="text" id="option_d" name="option_d" value="{{ question_data.option_d if question_data else '' }}" required>
+
+        <label>正确答案</label>
         {% set selected = question_data.correct_option if question_data else '' %}
         <div class="radio-group">
-            <label><input type="radio" name="correct_option" value="A" {% if selected == 'A' %}checked{% endif %}> A</label>
-            <label><input type="radio" name="correct_option" value="B" {% if selected == 'B' %}checked{% endif %}> B</label>
-            <label><input type="radio" name="correct_option" value="C" {% if selected == 'C' %}checked{% endif %}> C</label>
-            <label><input type="radio" name="correct_option" value="D" {% if selected == 'D' %}checked{% endif %}> D</label>
+            {% for key, label in correct_option_choices %}
+            <label><input type="radio" name="correct_option" value="{{ key }}" {% if selected == key %}checked{% endif %}> {{ label }}</label>
+            {% endfor %}
         </div>
-    </label>
-    <label>板块
-        {% set selected_sec = question_data.section if question_data else '' %}
-        <select name="section" required>
-            {% for sec in ['日语', '综合科目', '理科'] %}
-            <option value="{{ sec }}" {% if selected_sec == sec %}selected{% endif %}>{{ sec }}</option>
+
+        <label for="section">所属板块</label>
+        {% set selected_section = question_data.section if question_data else '' %}
+        <select id="section" name="section" required>
+            <option value="" disabled {% if not selected_section %}selected{% endif %}>请选择板块</option>
+            {% for sec in section_choices %}
+            <option value="{{ sec }}" {% if selected_section == sec %}selected{% endif %}>{{ sec }}</option>
             {% endfor %}
         </select>
-    </label>
-    <label>标签（用逗号分隔；层级用“/”分隔）
-        <input type="text" name="tags" value="{{ question_data.tags if question_data else '' }}">
-    </label>
-    <button type="submit">{% if action == 'edit' %}保存更改{% else %}添加题目{% endif %}</button>
-</form>
-</body>
-</html>
+
+        <label for="tags">标签（用逗号分隔；层级使用“/”）</label>
+        <input type="text" id="tags" name="tags" value="{{ question_data.tags if question_data else '' }}" placeholder="例如：数学/代数, 日本语/语法">
+        <div class="helper-text">示例：<code>数学/代数</code>、<code>综合科目/地理/气候</code>。使用逗号分隔多个标签，前缀可用于分类检索。</div>
+
+        <div class="form-actions">
+            <a class="btn btn-secondary" href="{{ request.url_for('admin') }}">返回后台</a>
+            <button class="btn btn-primary" type="submit">{% if action == 'edit' %}保存更改{% else %}添加题目{% endif %}</button>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/eju_app/templates/admin.html
+++ b/eju_app/templates/admin.html
@@ -1,71 +1,191 @@
-<!DOCTYPE html>
-<html lang="zh">
-<head>
-<meta charset="UTF-8">
-<title>后台管理 - EJU 题库</title>
-<style>
-body { font-family: sans-serif; margin: 2rem; background-color: #f9fafb; color: #333; }
-h1 { color: #007bff; }
-nav a { margin-right: 1rem; text-decoration: none; color: #007bff; }
-nav a.button {
-  display: inline-block;
-  padding: 0.5rem 1rem;
-  background-color: #28a745;
-  color: #fff;
-  border-radius: 4px;
+{% extends "base.html" %}
+{% block title %}后台管理 - EJU 题库{% endblock %}
+{% block extra_styles %}
+.admin-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.25rem;
 }
-nav a.button:hover { background-color: #218838; }
-table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-th, td { padding: 0.5rem; border: 1px solid #ddd; text-align: left; }
-th { background-color: #f1f1f1; }
-.actions a { margin-right: 0.5rem; text-decoration: none; color: #007bff; }
-.flash { padding: 0.5rem; margin-bottom: 1rem; border-radius: 4px; }
-.flash.error { background-color: #f8d7da; color: #842029; }
-.flash.success { background-color: #d1e7dd; color: #0f5132; }
-</style>
-</head>
-<body>
-<h1>后台管理</h1>
-<nav>
-    <a href="{{ url_for('home') }}">返回首页</a>
-    <a class="button" href="{{ url_for('add_question_get') }}">添加新题目</a>
-    <a class="button" href="{{ url_for('quiz') }}">前往学生答题</a>
-</nav>
 
-{% if msg %}
-<div class="flash {{ category }}">{{ msg }}</div>
-{% endif %}
+.admin-header h1 {
+    margin: 0;
+}
 
+.filter-panel {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+    align-items: end;
+    margin-bottom: 1.25rem;
+}
+
+.filter-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.filter-actions .btn {
+    flex: 1 1 120px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--card-bg);
+    border-radius: 10px;
+    overflow: hidden;
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+}
+
+th, td {
+    padding: 0.75rem 0.9rem;
+    border-bottom: 1px solid var(--border-color);
+    vertical-align: top;
+    text-align: left;
+}
+
+th {
+    background: #f8f9fb;
+    font-weight: 600;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.78rem;
+}
+
+tbody tr:hover {
+    background: #f8fafd;
+}
+
+.tag-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+}
+
+.tag-badges span {
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    background: #e7f1ff;
+    color: var(--primary);
+    font-size: 0.78rem;
+}
+
+.actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.actions a,
+.actions button {
+    text-decoration: none;
+    padding: 0.35rem 0.65rem;
+    border-radius: 6px;
+    border: none;
+    background: #e9ecef;
+    color: var(--text-color);
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+
+.actions a:hover,
+.actions button:hover {
+    background: #dde1e6;
+}
+
+.empty-row {
+    text-align: center;
+    color: var(--muted);
+}
+{% endblock %}
+{% block content %}
+<div class="admin-header">
+    <div>
+        <h1>后台管理</h1>
+        <p class="subtitle">共 {{ questions|length }} 道题目。可按板块、标签与关键词检索。</p>
+    </div>
+    <a class="btn btn-primary" href="{{ request.url_for('add_question_get') }}">添加新题目</a>
+</div>
+<form method="get" class="filter-panel">
+    <div>
+        <label for="section">板块</label>
+        <select name="section" id="section">
+            <option value="">全部板块</option>
+            {% for section in sections %}
+            <option value="{{ section.name }}" {% if section.name == selected_section %}selected{% endif %}>{{ section.display_name }} ({{ section.count }})</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div>
+        <label for="tag-select">标签</label>
+        <select name="tag" id="tag-select">
+            <option value="">全部标签</option>
+            {% for option in tag_options %}
+            <option value="{{ option.value }}" {% if option.value == selected_tag %}selected{% endif %}>
+                {{ "\u00a0\u00a0" * option.level }}{{ option.label }}
+            </option>
+            {% endfor %}
+        </select>
+    </div>
+    <div>
+        <label for="search">关键词</label>
+        <input type="text" name="search" id="search" value="{{ search }}" placeholder="题干或标签关键词">
+    </div>
+    <div class="filter-actions">
+        <button class="btn btn-primary" type="submit">应用筛选</button>
+        <a class="btn btn-secondary" href="{{ request.url_for('admin') }}">重置</a>
+    </div>
+</form>
 <table>
     <thead>
         <tr>
-            <th>ID</th>
-            <th>题目</th>
-            <th>标签</th>
-            <th>板块</th>
-            <th>正确答案</th>
-            <th>操作</th>
+            <th style="width:4rem;">ID</th>
+            <th style="width:30%;">题目</th>
+            <th style="width:18%;">板块</th>
+            <th style="width:24%;">标签</th>
+            <th style="width:10%;">正确答案</th>
+            <th style="width:14%;">操作</th>
         </tr>
     </thead>
     <tbody>
-        {% for q in questions %}
-        <tr>
-            <td>{{ q['id'] }}</td>
-            <td>{{ q['question']|truncate(60) }}</td>
-            <td>{{ q['tags'] }}</td>
-            <td>{{ q['section'] }}</td>
-            <td>{{ q['correct_option'] }}</td>
-            <td class="actions">
-                <a href="{{ url_for('edit_question_get', qid=q['id']) }}">编辑</a>
-                <a href="#" onclick="if(confirm('确认删除此题目？')){ document.getElementById('del-{{ q['id'] }}').submit(); } return false;">删除</a>
-                <form id="del-{{ q['id'] }}" method="post" action="{{ url_for('delete_question', qid=q['id']) }}" style="display:none;"></form>
-            </td>
-        </tr>
-        {% endfor %}
-        {% if questions|length == 0 %}
-        <tr><td colspan="6">没有题目。</td></tr>
+        {% if questions %}
+            {% for q in questions %}
+            <tr>
+                <td>{{ q.id }}</td>
+                <td>{{ q.question }}</td>
+                <td>{{ q.section or '未分类' }}</td>
+                <td>
+                    <div class="tag-badges">
+                        {% if q.tag_list %}
+                            {% for tag in q.tag_list %}
+                            <span>{{ tag }}</span>
+                            {% endfor %}
+                        {% else %}
+                            <span style="background:#f1f3f5;color:var(--muted);">无标签</span>
+                        {% endif %}
+                    </div>
+                </td>
+                <td>{{ q.correct_option }}</td>
+                <td>
+                    <div class="actions">
+                        <a href="{{ request.url_for('edit_question_get', qid=q.id) }}">编辑</a>
+                        <form method="post" action="{{ request.url_for('delete_question', qid=q.id) }}" onsubmit="return confirm('确认删除此题目？');">
+                            <button type="submit">删除</button>
+                        </form>
+                    </div>
+                </td>
+            </tr>
+            {% endfor %}
+        {% else %}
+        <tr><td colspan="6" class="empty-row">暂无题目，请添加新题目。</td></tr>
         {% endif %}
     </tbody>
 </table>
-</body>
-</html>
+{% endblock %}

--- a/eju_app/templates/base.html
+++ b/eju_app/templates/base.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block title %}EJU 题库{% endblock %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        :root {
+            color-scheme: light;
+            --primary: #0d6efd;
+            --primary-dark: #0b5ed7;
+            --success: #198754;
+            --danger: #dc3545;
+            --warning: #ffc107;
+            --border-color: #dee2e6;
+            --background: #f6f7fb;
+            --card-bg: #ffffff;
+            --text-color: #343a40;
+            --muted: #6c757d;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: "Segoe UI", system-ui, -apple-system, "PingFang SC", "Microsoft YaHei", sans-serif;
+            background: var(--background);
+            color: var(--text-color);
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        header {
+            background: #ffffff;
+            border-bottom: 1px solid var(--border-color);
+            position: sticky;
+            top: 0;
+            z-index: 100;
+        }
+
+        .container {
+            width: min(1100px, 96vw);
+            margin: 0 auto;
+            padding: 1.5rem 0;
+        }
+
+        .topbar {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 1rem 0;
+        }
+
+        .brand {
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: var(--primary);
+            text-decoration: none;
+        }
+
+        nav a {
+            margin-left: 1rem;
+            text-decoration: none;
+            color: var(--muted);
+            font-weight: 500;
+        }
+
+        nav a.active,
+        nav a:hover {
+            color: var(--primary);
+        }
+
+        main {
+            flex: 1;
+            padding-bottom: 3rem;
+        }
+
+        footer {
+            background: #ffffff;
+            border-top: 1px solid var(--border-color);
+            text-align: center;
+            padding: 1rem 0;
+            font-size: 0.9rem;
+            color: var(--muted);
+        }
+
+        .flash {
+            padding: 0.75rem 1rem;
+            border-radius: 6px;
+            margin-bottom: 1rem;
+        }
+
+        .flash.success {
+            background: #d1e7dd;
+            color: #0f5132;
+            border: 1px solid #badbcc;
+        }
+
+        .flash.error {
+            background: #f8d7da;
+            color: #842029;
+            border: 1px solid #f5c2c7;
+        }
+
+        .flash.info {
+            background: #cff4fc;
+            color: #055160;
+            border: 1px solid #b6effb;
+        }
+
+        .section-title {
+            font-size: 1.75rem;
+            margin-bottom: 0.5rem;
+            color: var(--text-color);
+        }
+
+        .subtitle {
+            color: var(--muted);
+            margin-bottom: 1.5rem;
+        }
+
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.25rem;
+            padding: 0.5rem 1rem;
+            border-radius: 6px;
+            text-decoration: none;
+            font-weight: 600;
+            border: none;
+            cursor: pointer;
+        }
+
+        .btn-primary {
+            background: var(--primary);
+            color: #ffffff;
+        }
+
+        .btn-primary:hover {
+            background: var(--primary-dark);
+        }
+
+        .btn-secondary {
+            background: #e9ecef;
+            color: var(--text-color);
+        }
+
+        .btn-secondary:hover {
+            background: #dde1e6;
+        }
+
+        form {
+            margin: 0;
+        }
+
+        input[type="text"],
+        textarea,
+        select {
+            width: 100%;
+            padding: 0.5rem 0.65rem;
+            border-radius: 6px;
+            border: 1px solid var(--border-color);
+            font-size: 1rem;
+            transition: border-color .2s ease;
+        }
+
+        input[type="text"]:focus,
+        textarea:focus,
+        select:focus {
+            border-color: var(--primary);
+            outline: none;
+            box-shadow: 0 0 0 3px rgba(13,110,253,0.15);
+        }
+
+        @media (max-width: 640px) {
+            .topbar {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 0.5rem;
+            }
+
+            nav a {
+                margin: 0 0.75rem 0.25rem 0;
+            }
+        }
+
+        {% block extra_styles %}{% endblock %}
+    </style>
+</head>
+<body>
+<header>
+    <div class="container topbar">
+        <a class="brand" href="{{ request.url_for('home') }}">EJU 题库</a>
+        <nav>
+            <a href="{{ request.url_for('home') }}" class="{% if request.url.path == '/' %}active{% endif %}">首页</a>
+            <a href="{{ request.url_for('quiz') }}" class="{% if request.url.path.startswith('/quiz') %}active{% endif %}">学生答题</a>
+            <a href="{{ request.url_for('admin') }}" class="{% if request.url.path.startswith('/admin') and 'edit' not in request.url.path and 'add' not in request.url.path %}active{% endif %}">后台管理</a>
+        </nav>
+    </div>
+</header>
+<main>
+    <div class="container">
+        {% if feedback %}
+            {% for item in feedback %}
+                <div class="flash {{ item.category }}">{{ item.text }}</div>
+            {% endfor %}
+        {% endif %}
+        {% block content %}{% endblock %}
+    </div>
+</main>
+<footer>
+    <div class="container">EJU 题库 · 更高效地练习与分类检索题目</div>
+</footer>
+{% block extra_scripts %}{% endblock %}
+</body>
+</html>

--- a/eju_app/templates/home.html
+++ b/eju_app/templates/home.html
@@ -1,39 +1,123 @@
-<!DOCTYPE html>
-<html lang="zh">
-<head>
-<meta charset="UTF-8">
-<title>选择板块 - EJU 题库</title>
-<style>
-body { font-family: sans-serif; margin: 2rem; background-color: #f9fafb; color: #333; }
-h1 { color: #007bff; }
-p { margin-top: 0.5rem; }
-.sections { display: flex; gap: 1rem; flex-wrap: wrap; }
+{% extends "base.html" %}
+{% block title %}首页 - EJU 题库{% endblock %}
+{% block extra_styles %}
+.section-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.25rem;
+}
+
 .section-card {
-  flex: 1 1 200px;
-  padding: 1.5rem;
-  background-color: #fff;
-  border-radius: 6px;
-  border: 1px solid #ddd;
-  text-align: center;
-  cursor: pointer;
-  text-decoration: none;
-  color: inherit;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-  transition: transform .2s ease;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+    transition: transform .2s ease, box-shadow .2s ease;
+    text-decoration: none;
+    color: inherit;
 }
+
 .section-card:hover {
-  transform: translateY(-4px);
-  background-color: #f0f8ff;
+    transform: translateY(-4px);
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
 }
-</style>
-</head>
-<body>
-<h1>欢迎来到 EJU 题库</h1>
-<p>请选择你想练习的板块：</p>
-<div class="sections">
-    <a class="section-card" href="{{ url_for('quiz') }}?section=日语">日语</a>
-    <a class="section-card" href="{{ url_for('quiz') }}?section=综合科目">综合科目</a>
-    <a class="section-card" href="{{ url_for('quiz') }}?section=理科">理科</a>
+
+.section-count {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--primary);
+}
+
+.section-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+}
+
+.tag-chip {
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    background: #e7f1ff;
+    color: var(--primary);
+    font-size: 0.85rem;
+}
+
+.quick-actions {
+    margin-top: 2rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.quick-actions .btn {
+    min-width: 160px;
+    justify-content: center;
+}
+
+.tag-cloud {
+    margin-top: 2.5rem;
+}
+
+.tag-cloud-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.tag-cloud-list a {
+    text-decoration: none;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: #fff;
+    border: 1px solid var(--border-color);
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.tag-cloud-list a:hover {
+    border-color: var(--primary);
+    color: var(--primary);
+}
+{% endblock %}
+{% block content %}
+<h1 class="section-title">欢迎来到 EJU 题库</h1>
+<p class="subtitle">当前共收录 <strong>{{ total_questions }}</strong> 道题目，可按板块与标签快速检索。</p>
+<div class="section-grid">
+    {% for section in sections %}
+    <a class="section-card" href="{{ request.url_for('quiz') }}?section={{ section.name | urlencode }}">
+        <div class="section-title" style="margin:0; font-size:1.4rem;">{{ section.display_name }}</div>
+        <div class="section-count">{{ section.count }}</div>
+        <div class="section-tags">
+            {% if section.top_tags %}
+                {% for tag in section.top_tags %}
+                <span class="tag-chip">{{ tag }}</span>
+                {% endfor %}
+            {% else %}
+                <span class="tag-chip" style="background:#f1f3f5;color:var(--muted);">暂无标签</span>
+            {% endif %}
+        </div>
+    </a>
+    {% endfor %}
 </div>
-</body>
-</html>
+<div class="quick-actions">
+    <a class="btn btn-primary" href="{{ request.url_for('quiz') }}">开始练习</a>
+    <a class="btn btn-secondary" href="{{ request.url_for('admin') }}">管理题库</a>
+    <a class="btn btn-secondary" href="{{ request.url_for('add_question_get') }}">添加新题目</a>
+</div>
+<div class="tag-cloud">
+    <h2 style="font-size:1.3rem; margin-bottom:0.75rem;">热门分类标签</h2>
+    <div class="tag-cloud-list">
+        {% if top_tags %}
+            {% for tag in top_tags %}
+            <a href="{{ request.url_for('quiz') }}?tag={{ tag | urlencode }}">{{ tag }}</a>
+            {% endfor %}
+        {% else %}
+            <span style="color:var(--muted);">暂无标签数据。</span>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/eju_app/templates/quiz.html
+++ b/eju_app/templates/quiz.html
@@ -1,83 +1,229 @@
-<!DOCTYPE html>
-<html lang="zh">
-<head>
-<meta charset="UTF-8">
-<title>{{ selected_section if selected_section else '题目' }} - 学生答题 - EJU 题库</title>
-<style>
-body { font-family: sans-serif; margin: 2rem; background-color: #f9fafb; color: #333; }
-header { display: flex; justify-content: space-between; align-items: center; }
-header h1 { color: #007bff; margin: 0; }
-header nav a { margin-left: 1rem; text-decoration: none; color: #007bff; }
-.question-card {
-  margin-bottom: 1.5rem;
-  padding: 1rem;
-  background-color: #fff;
-  border: 1px solid #ddd;
-  border-radius: 4px;
+{% extends "base.html" %}
+{% block title %}{{ selected_section_display }} - 学生答题 - EJU 题库{% endblock %}
+{% block extra_styles %}
+.page-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
 }
-.question-card h3 { margin-top: 0; }
-.options label { display: block; margin-bottom: 0.3rem; }
-button {
-  margin-top: 1rem;
-  padding: 0.5rem 1rem;
-  background-color: #28a745;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-}
-button:hover { background-color: #218838; }
-.filter { margin-bottom: 1rem; }
-select { padding: 0.3rem; border-radius: 4px; border: 1px solid #ccc; }
-</style>
-</head>
-<body>
-<header>
-    <div><h1>{{ selected_section or '全部题目' }}</h1></div>
-    <nav>
-        <a href="{{ url_for('home') }}">首页</a>
-    </nav>
-</header>
 
-<div class="filter">
-    <form method="get" action="{{ url_for('quiz') }}">
-        <input type="hidden" name="section" value="{{ selected_section }}">
-        <label for="tag-select">按标签筛选：</label>
-        <select name="tag" id="tag-select">
-            <option value="">-- 全部 --</option>
-            {% for parent, children in tags_hierarchy.items() %}
-                {% if children %}
-                    <optgroup label="{{ parent }}">
-                        {% for child in children %}
-                            <option value="{{ parent ~ '/' ~ child }}" {% if selected_tag == parent ~ '/' ~ child %}selected{% endif %}>{{ child }}</option>
-                        {% endfor %}
-                    </optgroup>
-                {% else %}
-                    <option value="{{ parent }}" {% if selected_tag == parent %}selected{% endif %}>{{ parent }}</option>
-                {% endif %}
+.page-header h1 {
+    margin: 0;
+    font-size: 1.8rem;
+}
+
+.filter-panel {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+    align-items: end;
+    margin-bottom: 1.5rem;
+}
+
+.filter-panel label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--muted);
+    display: block;
+    margin-bottom: 0.35rem;
+}
+
+.filter-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.filter-actions .btn {
+    flex: 1 1 120px;
+}
+
+.quiz-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.question-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 1.25rem;
+    box-shadow: 0 4px 14px rgba(15, 23, 42, 0.08);
+}
+
+.question-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.question-title {
+    margin: 0;
+    font-size: 1.1rem;
+    line-height: 1.6;
+}
+
+.meta-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-top: 0.5rem;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    background: #e7f5ff;
+    color: var(--primary);
+}
+
+.badge.muted {
+    background: #f1f3f5;
+    color: var(--muted);
+}
+
+.options {
+    margin-top: 0.75rem;
+    display: grid;
+    gap: 0.5rem;
+}
+
+.options label {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    background: #f8f9fb;
+    border-radius: 8px;
+    padding: 0.55rem 0.75rem;
+    border: 1px solid transparent;
+    transition: border-color .2s ease, background .2s ease;
+}
+
+.options label:hover {
+    border-color: var(--primary);
+    background: #fff;
+}
+
+.options input[type="radio"] {
+    margin-top: 0.2rem;
+}
+
+.submit-area {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+}
+
+.empty-state {
+    background: #fff3cd;
+    border: 1px solid #ffe69c;
+    color: #856404;
+    padding: 1rem 1.25rem;
+    border-radius: 10px;
+}
+
+.active-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: var(--muted);
+}
+
+.active-filters span {
+    background: #e9ecef;
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+}
+{% endblock %}
+{% block content %}
+<div class="page-header">
+    <div>
+        <h1>{{ selected_section_display }}</h1>
+        <p class="subtitle">共 {{ questions|length }} 道题目{% if selected_tag_label or search %}（已应用筛选）{% endif %}</p>
+    </div>
+    {% if selected_tag_label or search or selected_section %}
+    <div class="active-filters">
+        {% if selected_section %}<span>板块：{{ selected_section_display }}</span>{% endif %}
+        {% if selected_tag_label %}<span>标签：{{ selected_tag_label }}</span>{% endif %}
+        {% if search %}<span>关键词：{{ search }}</span>{% endif %}
+    </div>
+    {% endif %}
+</div>
+<form method="get" class="filter-panel">
+    <div>
+        <label for="section">板块</label>
+        <select name="section" id="section">
+            <option value="">全部板块</option>
+            {% for section in sections %}
+            <option value="{{ section.name }}" {% if section.name == selected_section %}selected{% endif %}>{{ section.display_name }} ({{ section.count }})</option>
             {% endfor %}
         </select>
-        <button type="submit">应用</button>
-    </form>
-</div>
-
-<form method="post">
+    </div>
+    <div>
+        <label for="tag-select">标签</label>
+        <select name="tag" id="tag-select">
+            <option value="">全部标签</option>
+            {% for option in tag_options %}
+            <option value="{{ option.value }}" {% if option.value == selected_tag %}selected{% endif %}>
+                {{ "\u00a0\u00a0" * option.level }}{{ option.label }}
+            </option>
+            {% endfor %}
+        </select>
+    </div>
+    <div>
+        <label for="search">关键词</label>
+        <input type="text" name="search" id="search" value="{{ search }}" placeholder="输入题干或选项关键词">
+    </div>
+    <div class="filter-actions">
+        <button class="btn btn-primary" type="submit">应用筛选</button>
+        <a class="btn btn-secondary" href="{{ request.url_for('quiz') }}">重置</a>
+    </div>
+</form>
+<form method="post" class="quiz-form">
     {% if questions|length == 0 %}
-        <p>没有题目可供选择。</p>
+    <div class="empty-state">
+        暂无符合条件的题目。您可以 <a href="{{ request.url_for('quiz') }}">清除筛选</a> 或 <a href="{{ request.url_for('add_question_get') }}">前往后台添加题目</a>。
+    </div>
     {% else %}
         {% for q in questions %}
         <div class="question-card">
-            <h3>{{ loop.index }}. {{ q['question'] }}</h3>
+            <div class="question-header">
+                <h3 class="question-title">{{ loop.index }}. {{ q.question }}</h3>
+                <span class="badge muted">ID：{{ q.id }}</span>
+            </div>
+            <div class="meta-tags">
+                <span class="badge muted">板块：{{ q.section or '未分类' }}</span>
+                {% if q.tag_list %}
+                    {% for tag in q.tag_list %}
+                    <span class="badge">{{ tag }}</span>
+                    {% endfor %}
+                {% else %}
+                    <span class="badge muted">无标签</span>
+                {% endif %}
+            </div>
             <div class="options">
-                <label><input type="radio" name="question-{{ q['id'] }}" value="A"> A. {{ q['option_a'] }}</label>
-                <label><input type="radio" name="question-{{ q['id'] }}" value="B"> B. {{ q['option_b'] }}</label>
-                <label><input type="radio" name="question-{{ q['id'] }}" value="C"> C. {{ q['option_c'] }}</label>
-                <label><input type="radio" name="question-{{ q['id'] }}" value="D"> D. {{ q['option_d'] }}</label>
+                <label><input type="radio" name="question-{{ q.id }}" value="A" {% if loop.first %}required{% endif %}> <strong>A.</strong> {{ q.option_a }}</label>
+                <label><input type="radio" name="question-{{ q.id }}" value="B"> <strong>B.</strong> {{ q.option_b }}</label>
+                <label><input type="radio" name="question-{{ q.id }}" value="C"> <strong>C.</strong> {{ q.option_c }}</label>
+                <label><input type="radio" name="question-{{ q.id }}" value="D"> <strong>D.</strong> {{ q.option_d }}</label>
             </div>
         </div>
         {% endfor %}
-        <button type="submit">提交答案</button>
+        <div class="submit-area">
+            <a class="btn btn-secondary" href="{{ request.url_for('quiz') }}">重新加载题目</a>
+            <button class="btn btn-primary" type="submit">提交答案</button>
+        </div>
     {% endif %}
 </form>
-</body>
-</html>
+{% endblock %}

--- a/eju_app/templates/result.html
+++ b/eju_app/templates/result.html
@@ -1,49 +1,165 @@
-<!DOCTYPE html>
-<html lang="zh">
-<head>
-<meta charset="UTF-8">
-<title>答题结果 - EJU 题库</title>
-<style>
-body { font-family: sans-serif; margin: 2rem; background-color: #f9fafb; color: #333; }
-h1 { color: #007bff; }
-table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
-th, td { padding: 0.5rem; border: 1px solid #ddd; text-align: left; }
-th { background-color: #f1f1f1; }
-.correct { color: #198754; }
-.wrong { color: #dc3545; }
-a.button { display: inline-block; padding: 0.5rem 1rem; background-color: #0d6efd; color: #fff; text-decoration: none; border-radius: 4px; margin-top: 1rem; }
-a.button:hover { background-color: #0b5ed7; }
-</style>
-</head>
-<body>
-<h1>答题结果</h1>
-<p>总题数：{{ total }}，答对：{{ correct }}，得分：{{ score }}%</p>
-<table>
-    <thead>
-        <tr>
-            <th>题目 ID</th>
-            <th>你的答案</th>
-            <th>正确答案</th>
-            <th>结果</th>
-        </tr>
-    </thead>
-    <tbody>
+{% extends "base.html" %}
+{% block title %}答题结果 - EJU 题库{% endblock %}
+{% block extra_styles %}
+.score-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+    text-align: center;
+}
+
+.score-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.score-item span:first-child {
+    font-size: 0.9rem;
+    color: var(--muted);
+}
+
+.score-item strong {
+    font-size: 1.8rem;
+    color: var(--primary);
+}
+
+.question-review {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.review-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+}
+
+.review-header {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.review-header h3 {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.answer-status {
+    font-weight: 700;
+}
+
+.answer-status.correct {
+    color: var(--success);
+}
+
+.answer-status.wrong {
+    color: var(--danger);
+}
+
+.answer-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-top: 0.5rem;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.options-list {
+    margin-top: 0.75rem;
+    display: grid;
+    gap: 0.4rem;
+}
+
+.options-list span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.45rem 0.6rem;
+    border-radius: 8px;
+    background: #f8f9fb;
+}
+
+.options-list span.correct {
+    background: rgba(25, 135, 84, 0.15);
+    color: var(--success);
+}
+
+.options-list span.selected {
+    border: 1px solid var(--primary);
+}
+
+.review-actions {
+    margin-top: 2rem;
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.review-actions .btn {
+    min-width: 160px;
+    justify-content: center;
+}
+{% endblock %}
+{% block content %}
+<h1 class="section-title">答题结果</h1>
+<div class="score-card">
+    <div class="score-item">
+        <span>答题数量</span>
+        <strong>{{ total }}</strong>
+    </div>
+    <div class="score-item">
+        <span>答对题数</span>
+        <strong>{{ correct }}</strong>
+    </div>
+    <div class="score-item">
+        <span>正确率</span>
+        <strong>{{ score }}%</strong>
+    </div>
+</div>
+<div class="question-review">
+    {% if details %}
         {% for item in details %}
-        <tr>
-            <td>{{ item.id }}</td>
-            <td>{{ item.user_answer }}</td>
-            <td>{{ item.correct_answer }}</td>
-            <td class="{{ 'correct' if item.is_correct else 'wrong' }}">
-                {% if item.is_correct %}正确{% else %}错误{% endif %}
-            </td>
-        </tr>
+        <div class="review-card">
+            <div class="review-header">
+                <h3>{{ loop.index }}. {{ item.question }}</h3>
+                <span class="answer-status {{ 'correct' if item.is_correct else 'wrong' }}">
+                    {% if item.is_correct %}回答正确{% else %}回答错误{% endif %}
+                </span>
+            </div>
+            <div class="answer-meta">
+                <span>题目 ID：{{ item.id }}</span>
+                <span>板块：{{ item.section or '未分类' }}</span>
+                {% if item.tag_list %}
+                    <span>标签：{{ item.tag_list | join(', ') }}</span>
+                {% endif %}
+                <span>你的答案：{{ item.user_answer or '未作答' }}</span>
+                <span>正确答案：{{ item.correct_answer }}</span>
+            </div>
+            <div class="options-list">
+                {% for key, text in item.options %}
+                <span class="{% if key == item.correct_answer %}correct{% endif %} {% if key == item.user_answer %}selected{% endif %}"><strong>{{ key }}.</strong> {{ text }}</span>
+                {% endfor %}
+            </div>
+        </div>
         {% endfor %}
-        {% if details|length == 0 %}
-        <tr><td colspan="4">没有答题记录。</td></tr>
-        {% endif %}
-    </tbody>
-</table>
-<a class="button" href="{{ url_for('quiz') }}">继续答题</a>
-<a class="button" href="{{ url_for('home') }}">返回首页</a>
-</body>
-</html>
+    {% else %}
+        <div class="flash info">暂无答题记录。</div>
+    {% endif %}
+</div>
+<div class="review-actions">
+    <a class="btn btn-primary" href="{{ request.url_for('quiz') }}">继续练习</a>
+    <a class="btn btn-secondary" href="{{ request.url_for('home') }}">返回首页</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- introduce a shared base layout and refreshed pages for home, quiz, admin and result views so the quiz experience is cleaner and easier to navigate
- add hierarchical tag helpers, section statistics and form validation to power section/tag filters and safer question management
- enrich the quiz workflow with keyword search, clearer metadata chips and detailed result breakdowns for review

## Testing
- python -m compileall eju_app

------
https://chatgpt.com/codex/tasks/task_e_68cc47a163a48322b78d958e19d56f14